### PR TITLE
Updated sklearn API

### DIFF
--- a/src/affinity_propagation.rs
+++ b/src/affinity_propagation.rs
@@ -289,19 +289,19 @@ where
         let s = s.similarity(x);
         let s_dim = s.dim();
         assert_eq!(s_dim.0, s_dim.1, "similarity dim must be NxN");
-        let mut calculation = Calculation {
-            similarity: s,
-            responsibility: Array2::zeros(s_dim),
-            availability: Array2::zeros(s_dim),
-            damping: self.damping,
-        };
-        calculation.add_preference_to_sim(self.preference);
 
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads)
             .build()
             .unwrap();
         let results = pool.scope(move |_| {
+            let mut calculation = Calculation {
+                similarity: s,
+                responsibility: Array2::zeros(s_dim),
+                availability: Array2::zeros(s_dim),
+                damping: self.damping,
+            };
+            calculation.add_preference_to_sim(self.preference);
             for _ in 0..self.convergence_iter {
                 calculation.update_r();
                 calculation.update_a();

--- a/src/affinity_propagation.rs
+++ b/src/affinity_propagation.rs
@@ -1,10 +1,15 @@
 use ndarray::{Array1, Array2, ArrayView, Axis, Dim, Zip};
 use num_traits::Float;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use std::cmp::Eq;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
+use std::hash::Hash;
 
-pub trait Similarity<F> {
+pub trait Similarity<F>
+where
+    F: Float + Send + Sync,
+{
     type UserType;
     fn similarity(self, x: Array2<Self::UserType>) -> Array2<F>;
 }
@@ -19,7 +24,7 @@ impl Default for Euclidean {
 
 impl<F> Similarity<F> for Euclidean
 where
-    F: Float,
+    F: Float + Send + Sync,
 {
     type UserType = F;
 
@@ -44,145 +49,17 @@ where
     }
 }
 
-/// Implementation derived from sklearn AffinityPropagation implementation
-/// https://github.com/scikit-learn/scikit-learn/blob/0d378913b/sklearn/cluster/_affinity_propagation.py#L38
-pub struct AffinityPropagation<F> {
+struct Calculation<F> {
     similarity: Array2<F>,
     responsibility: Array2<F>,
     availability: Array2<F>,
-    pub exemplar_map: HashMap<usize, Vec<usize>>,
     damping: F,
-    threads: usize,
-    max_iterations: usize,
-    convergence_iter: usize,
-    preference: F,
-    converged: bool,
 }
 
-impl<F> AffinityPropagation<F>
+impl<F> Calculation<F>
 where
     F: Float + Send + Sync,
 {
-    /// Generate cluster predictions for set of `x` values and `y` labels
-    /// - x: 2-D array of (rows=samples, cols=attr_values)
-    /// - y: 1-D array of label values attached to each row in `x`
-    /// - s: Similarity calculator -> must generate an N x N matrix
-    pub fn new<S>(
-        x: Array2<S::UserType>,
-        s: S,
-        damping: F,
-        threads: usize,
-        max_iterations: usize,
-        convergence_iter: usize,
-        preference: F,
-    ) -> Self
-    where
-        S: Similarity<F>,
-    {
-        let s = s.similarity(x);
-        let s_dim = s.dim();
-        assert_eq!(s_dim.0, s_dim.1, "similarity dim must be NxN");
-        let mut ap = Self {
-            similarity: s,
-            responsibility: Array2::<F>::zeros(s_dim),
-            availability: Array2::<F>::zeros(s_dim),
-            exemplar_map: HashMap::new(),
-            damping,
-            threads,
-            max_iterations,
-            convergence_iter,
-            preference,
-            converged: false,
-        };
-        ap.add_preference_to_sim();
-        ap
-    }
-
-    pub fn with_defaults<S>(x: Array2<S::UserType>, s: S) -> Self
-    where
-        S: Similarity<F>,
-    {
-        let s = s.similarity(x);
-        let s_dim = s.dim();
-        assert_eq!(s_dim.0, s_dim.1, "similarity dim must be NxN");
-        let mut ap = Self {
-            similarity: s,
-            responsibility: Array2::<F>::zeros(s_dim),
-            availability: Array2::<F>::zeros(s_dim),
-            exemplar_map: HashMap::new(),
-            damping: F::from(0.5).unwrap(),
-            threads: 4,
-            max_iterations: 100,
-            convergence_iter: 10,
-            preference: F::from(-10.).unwrap(),
-            converged: false,
-        };
-        ap.add_preference_to_sim();
-        ap
-    }
-
-    pub fn predict(&mut self) {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(self.threads)
-            .build()
-            .unwrap();
-        pool.scope(move |_| {
-            for _ in 0..self.convergence_iter {
-                self.update_r();
-                self.update_a();
-            }
-            let mut final_exemplars = self.generate_exemplars();
-            for _ in self.convergence_iter..self.max_iterations {
-                self.update_r();
-                self.update_a();
-                let sol_map = self.generate_exemplars();
-                if final_exemplars.len() == sol_map.len()
-                    && final_exemplars.iter().all(|k| sol_map.contains(k))
-                {
-                    self.converged = true;
-                    break;
-                }
-                final_exemplars = sol_map;
-            }
-            self.exemplar_map = self.generate_exemplar_map(final_exemplars);
-        });
-    }
-
-    pub fn results(&self) -> &HashMap<usize, Vec<usize>> {
-        &self.exemplar_map
-    }
-
-    pub fn display_results<L>(&self, labels: &[L])
-    where
-        L: Display + Clone + ToString,
-    {
-        println!(
-            "Converged={} nClusters={} nSamples={}",
-            self.converged,
-            self.exemplar_map.len(),
-            self.similarity.dim().0
-        );
-        self.exemplar_map
-            .iter()
-            .enumerate()
-            .for_each(|(idx, (key, value))| {
-                println!(
-                    ">Cluster={} size={} exemplar={}",
-                    idx + 1,
-                    value.len(),
-                    labels[*key]
-                );
-                println!(
-                    "{}",
-                    value
-                        .iter()
-                        .map(|v| labels[*v].to_string())
-                        .collect::<Vec<String>>()
-                        .join(",")
-                );
-            });
-    }
-
     fn generate_exemplars(&self) -> HashSet<usize> {
         let idx = Array1::<F>::range(
             F::from(0.).unwrap(),
@@ -242,9 +119,10 @@ where
         exemplar_map
     }
 
-    fn add_preference_to_sim(&mut self) {
-        let pref = self.preference;
-        self.similarity.diag_mut().par_map_inplace(|v| *v = pref);
+    fn add_preference_to_sim(&mut self, preference: F) {
+        self.similarity
+            .diag_mut()
+            .par_map_inplace(|v| *v = preference);
     }
 
     fn update_r(&mut self) {
@@ -343,6 +221,134 @@ where
             }
         });
         (max_pos, max)
+    }
+}
+
+/// Implementation derived from sklearn AffinityPropagation implementation
+/// https://github.com/scikit-learn/scikit-learn/blob/0d378913b/sklearn/cluster/_affinity_propagation.py#L38
+pub struct AffinityPropagation<F> {
+    damping: F,
+    preference: F,
+    threads: usize,
+    convergence_iter: usize,
+    max_iterations: usize,
+    pub converged: bool,
+}
+
+impl<F> Default for AffinityPropagation<F>
+where
+    F: Float + Send + Sync,
+{
+    fn default() -> Self {
+        Self {
+            damping: F::from(0.5).unwrap(),
+            threads: 4,
+            max_iterations: 100,
+            convergence_iter: 10,
+            preference: F::from(-10.).unwrap(),
+            converged: false,
+        }
+    }
+}
+
+impl<F> AffinityPropagation<F>
+where
+    F: Float + Send + Sync,
+{
+    /// Generate cluster predictions for set of `x` values and `y` labels
+    /// - x: 2-D array of (rows=samples, cols=attr_values)
+    /// - y: 1-D array of label values attached to each row in `x`
+    /// - s: Similarity calculator -> must generate an N x N matrix
+    pub fn new(
+        damping: F,
+        threads: usize,
+        max_iterations: usize,
+        convergence_iter: usize,
+        preference: F,
+    ) -> Self {
+        Self {
+            damping,
+            threads,
+            max_iterations,
+            convergence_iter,
+            preference,
+            converged: false,
+        }
+    }
+
+    pub fn predict<'a, S, L>(
+        &mut self,
+        x: Array2<S::UserType>,
+        y: &'a [L],
+        s: S,
+    ) -> HashMap<&'a L, Vec<&'a L>>
+    where
+        S: Similarity<F>,
+        L: Eq + Hash,
+    {
+        let s = s.similarity(x);
+        let s_dim = s.dim();
+        assert_eq!(s_dim.0, s_dim.1, "similarity dim must be NxN");
+        let mut calculation = Calculation {
+            similarity: s,
+            responsibility: Array2::zeros(s_dim),
+            availability: Array2::zeros(s_dim),
+            damping: self.damping,
+        };
+        calculation.add_preference_to_sim(self.preference);
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(self.threads)
+            .build()
+            .unwrap();
+        let results = pool.scope(move |_| {
+            for _ in 0..self.convergence_iter {
+                calculation.update_r();
+                calculation.update_a();
+            }
+            let mut final_exemplars = calculation.generate_exemplars();
+            for _ in self.convergence_iter..self.max_iterations {
+                calculation.update_r();
+                calculation.update_a();
+                let sol_map = calculation.generate_exemplars();
+                if final_exemplars.len() == sol_map.len()
+                    && final_exemplars.iter().all(|k| sol_map.contains(k))
+                {
+                    self.converged = true;
+                    break;
+                }
+                final_exemplars = sol_map;
+            }
+            calculation.generate_exemplar_map(final_exemplars)
+        });
+        HashMap::from_iter(
+            results
+                .into_iter()
+                .map(|(key, value)| (&y[key], value.iter().map(|v| &y[*v]).collect::<Vec<&L>>())),
+        )
+    }
+
+    pub fn display_results<'a, L>(&self, results: &HashMap<&'a L, Vec<&'a L>>)
+    where
+        L: Display + Clone + ToString,
+    {
+        println!(
+            "Converged={} nClusters={} nSamples={}",
+            self.converged,
+            results.len(),
+            results.iter().map(|(_, v)| v.len()).sum::<usize>()
+        );
+        results.iter().enumerate().for_each(|(idx, (key, value))| {
+            println!(">Cluster={} size={} exemplar={}", idx + 1, value.len(), key);
+            println!(
+                "{}",
+                value
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        });
     }
 }
 

--- a/src/affinity_propagation.rs
+++ b/src/affinity_propagation.rs
@@ -6,7 +6,6 @@ use std::fmt::Display;
 
 pub trait Similarity<F> {
     type UserType;
-    type FloatType;
     fn similarity(self, x: Array2<Self::UserType>) -> Array2<F>;
 }
 
@@ -23,7 +22,6 @@ where
     F: Float,
 {
     type UserType = F;
-    type FloatType = F;
 
     /// Row-by-row similarity calculation using negative euclidean distance
     fn similarity(self, x: Array2<Self::UserType>) -> Array2<F> {
@@ -156,7 +154,7 @@ where
 
     pub fn display_results<L>(&self, labels: &[L])
     where
-        L: Display + Send + Clone + ToString,
+        L: Display + Clone + ToString,
     {
         println!(
             "Converged={} nClusters={} nSamples={}",

--- a/src/bin/affinityprop/main.rs
+++ b/src/bin/affinityprop/main.rs
@@ -71,30 +71,26 @@ fn main() {
         "f64" => {
             let (x, y) = from_file::<f64>(Path::new(&input_file).to_path_buf());
             let mut ap = AffinityPropagation::new(
-                x,
-                Euclidean::default(),
                 damping,
                 threads,
                 max_iterations,
                 convergence_iter,
                 preference,
             );
-            ap.predict();
-            ap.display_results(&y);
+            let results = ap.predict(x, &y, Euclidean::default());
+            ap.display_results(&results);
         }
         _ => {
             let (x, y) = from_file::<f32>(Path::new(&input_file).to_path_buf());
             let mut ap = AffinityPropagation::new(
-                x,
-                Euclidean::default(),
                 damping as f32,
                 threads,
                 max_iterations,
                 convergence_iter,
                 preference as f32,
             );
-            ap.predict();
-            ap.display_results(&y);
+            let results = ap.predict(x, &y, Euclidean::default());
+            ap.display_results(&results);
         }
     };
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -6,10 +6,10 @@ mod test {
     #[test]
     fn simple() {
         let x: Array2<f32> = arr2(&[[1., 1., 1.], [2., 2., 2.], [3., 3., 3.]]);
-        let y = vec!["1".to_string(), "2".to_string(), "3".to_string()];
-        let mut ap = AffinityPropagation::with_defaults(x, Euclidean::default());
-        ap.predict();
-        assert!(ap.results().len() == 1 && ap.results().contains_key(&1));
-        ap.display_results(&y);
+        let y = vec!["1", "2", "3"];
+        let mut ap = AffinityPropagation::default();
+        let results = ap.predict(x, &y, Euclidean::default());
+        assert!(results.len() == 1 && results.contains_key(&"2"));
+        ap.display_results(&results);
     }
 }


### PR DESCRIPTION
Make implementation closer to sklearn API:

- Object creation for metadata collection
- `predict` method on actual x/y data (currently also provide similarity calculator)
- Drop intermediate data on calculation completion