### PR TITLE
Refactor: Move prediction algorithm to method in APAlgorithm

### DIFF
--- a/src/affinity_propagation.rs
+++ b/src/affinity_propagation.rs
@@ -107,28 +107,8 @@ where
             .build()
             .unwrap();
         pool.scope(move |_| {
-            let mut has_converged = false;
             let mut calculation = APAlgorithm::new(self.damping, self.preference, s);
-            for _ in 0..self.convergence_iter {
-                calculation.update();
-            }
-            let mut final_exemplars = calculation.generate_exemplars();
-            for _ in self.convergence_iter..self.max_iterations {
-                calculation.update();
-                let sol_map = calculation.generate_exemplars();
-                if !sol_map.is_empty()
-                    && final_exemplars.len() == sol_map.len()
-                    && final_exemplars.iter().all(|k| sol_map.contains(k))
-                {
-                    has_converged = true;
-                    break;
-                }
-                final_exemplars = sol_map;
-            }
-            (
-                has_converged,
-                calculation.generate_exemplar_map(final_exemplars),
-            )
+            calculation.predict(self.convergence_iter, self.max_iterations)
         })
     }
 }


### PR DESCRIPTION
Algorithm was directly written into AffinityPropagation::predict()

- Refactor to method of APAlgorithm (part of crate-public interface)
- Refactor prior crate-public methods to private